### PR TITLE
Move logo into home section

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,12 +32,15 @@
 <main>
     <section class="home" id="home">
         <div class="glass-card">
-            <h1>Καλώς ήρθατε στη Dust Cleaners</h1>
-            <p>Η πολυτέλεια ξεκινά από την καθαριότητα.
+            <img src="DustCleaner_Logo_Vertical_Color1.jpg" alt="Λογότυπο" class="logo-in-section">
+            <div class="glass-text">
+                <h1>Καλώς ήρθατε στη Dust Cleaners</h1>
+                <p>Η πολυτέλεια ξεκινά από την καθαριότητα.
 Στη Dust Cleaner, προσφέρουμε εξειδικευμένες λύσεις καθαρισμού για επαγγελματικούς και βιομηχανικούς χώρους, με έμφαση στη λεπτομέρεια, τη διακριτικότητα και την απόλυτη συνέπεια.
 Η ομάδα μας, εξοπλισμένη με τεχνολογία αιχμής και τεχνογνωσία ετών, εξασφαλίζει ένα περιβάλλον άψογα καθαρό, υγιεινό και εκλεπτυσμένο.
 Εμπιστευθείτε τη Dust Cleaner — γιατί ο χώρος σας δεν αξίζει τίποτα λιγότερο από το καλύτερο.</p>
-            <a href="#services" class="main-button">Μάθε περισσότερα</a>
+                <a href="#services" class="main-button">Μάθε περισσότερα</a>
+            </div>
         </div>
     </section>
 
@@ -107,10 +110,17 @@
 <script>
     setTimeout(() => {
       const logo = document.querySelector('.logo');
+      const logoSection = document.querySelector('.logo-in-section');
+      const card = document.querySelector('.glass-card');
       logo.classList.add('fade-out');
-  
+
       setTimeout(() => {
         document.body.classList.add('fixed-header');
+        logoSection.style.display = 'block';
+        card.classList.add('with-logo');
+        setTimeout(() => {
+          logoSection.classList.add('visible');
+        }, 10);
       }, 1600); // Δώσε χρόνο να γίνει το transition ΠΡΙΝ βάλεις το fixed-header
     }, 3000);
   </script>

--- a/style.css
+++ b/style.css
@@ -140,6 +140,10 @@ main {
   animation: fadeInUp 1.2s ease forwards;
   transform: translateY(20px);
   opacity: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 
 @keyframes fadeInUp {
@@ -183,6 +187,32 @@ main {
   font-weight: 400;
   line-height: 1.6;
   color: white;
+}
+
+.logo-in-section {
+  display: none;
+  height: 150px;
+  opacity: 0;
+  transition: opacity 0.8s ease;
+}
+
+.logo-in-section.visible {
+  opacity: 1;
+}
+
+.glass-text {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.glass-card.with-logo {
+  flex-direction: row;
+  text-align: left;
+}
+
+.glass-card.with-logo .glass-text {
+  margin-left: 20px;
 }
 
 /* Services Section */


### PR DESCRIPTION
## Summary
- reposition the logo into the first section after it fades out
- adjust homepage markup and style for side-by-side layout
- show logo with JS when header becomes fixed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852bedca484832c9595a23c6eaad29e