### PR TITLE
Adjust services section background and layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -196,10 +196,8 @@ main {
 
 .services {
   padding: 80px 20px;
-  background: linear-gradient(-45deg, #00c6ff, #0072ff, #5f72be, #9f44d3);
-  background-size: 400% 400%;
-  animation: gradientMove 15s ease infinite;
-  color: #fff;
+  background: #f9f9f9;
+  color: #333;
   text-align: center;
 }
 
@@ -223,13 +221,13 @@ main {
 /* Grid layout for services */
 .service-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 20px;
 }
 
 .service-card {
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: #fff;
+  border: 1px solid #e0e0e0;
   border-radius: 15px;
   padding: 30px 20px;
   transition: transform 0.3s, box-shadow 0.3s;
@@ -241,7 +239,7 @@ main {
 
 .service-card i {
   font-size: 40px;
-  color: #fff;
+  color: #0072ff;
   margin-bottom: 15px;
   display: inline-flex;
   justify-content: center;
@@ -249,17 +247,19 @@ main {
   width: 80px;
   height: 80px;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.15);
+  background: rgba(0, 114, 255, 0.1);
 }
 
 .service-card h3 {
   margin-bottom: 10px;
   font-size: 1.2rem;
+  color: #333;
 }
 
 .service-card p {
   font-size: 0.9rem;
   line-height: 1.5;
+  color: #555;
 }
 
 /* Clients Section */


### PR DESCRIPTION
## Summary
- restyle services section to use the same light background as the testimonials
- improve services grid layout with cleaner cards

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6852ced54e34832c83ea61640f630f59